### PR TITLE
MallocChecker extension - DeclarativeFunctionClassifier

### DIFF
--- a/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -26,9 +26,11 @@ add_clang_library(clangStaticAnalyzerCheckers
   ClangCheckers.cpp
   CloneChecker.cpp
   ConversionChecker.cpp
+  CppcheckDefinitionsParser.cpp
   CXXSelfAssignmentChecker.cpp
   DeadStoresChecker.cpp
   DebugCheckers.cpp
+  DeclarativeFunctionClassifier.cpp
   DeleteWithNonVirtualDtorChecker.cpp
   DereferenceChecker.cpp
   DirectIvarAssignment.cpp
@@ -112,3 +114,8 @@ add_clang_library(clangStaticAnalyzerCheckers
   clangLex
   clangStaticAnalyzerCore
   )
+
+if (CLANG_HAVE_LIBXML)
+  target_link_libraries(clangStaticAnalyzerCheckers PRIVATE ${LIBXML2_LIBRARIES})
+endif()
+

--- a/lib/StaticAnalyzer/Checkers/CppcheckDefinitionsParser.cpp
+++ b/lib/StaticAnalyzer/Checkers/CppcheckDefinitionsParser.cpp
@@ -1,0 +1,109 @@
+#include "CppcheckDefinitionsParser.h"
+#include <cassert>
+#include <memory>
+#include <type_traits>
+
+namespace clang {
+namespace ento {
+namespace {
+#ifdef CLANG_HAVE_LIBXML
+
+using XmlDocUPtr = std::unique_ptr<std::remove_pointer<xmlDocPtr>::type, void (*)(xmlDocPtr)>;
+using XmlCharUPtr = std::unique_ptr<xmlChar, void (*)(void *)>;
+
+const xmlChar* cast(const char* Str) {
+  return reinterpret_cast<const xmlChar*>(Str);
+}
+
+const char* cast(const xmlChar* Str) {
+  return reinterpret_cast<const char*>(Str);
+}
+
+XmlDocUPtr wrap(xmlDocPtr Doc) {
+  return {Doc, xmlFreeDoc};
+}
+
+XmlCharUPtr wrap(xmlChar* String) {
+  return {String, xmlFree};
+}
+
+#endif
+} // end namespace anonymous
+
+llvm::Error CppcheckDefinitionsParser::parse(StringRef Text, ParserCallback Callback) {
+  this->Callback = &Callback;
+  XmlDocUPtr Doc = wrap(xmlParseMemory(Text.data(), Text.size()));
+  if (!Doc) {
+    xmlErrorPtr XmlError = xmlGetLastError();
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "XML parsing error: %s",
+				   XmlError ? XmlError->message : "unknown error");
+  }
+  xmlNode *RootElement = xmlDocGetRootElement(Doc.get());
+  return parseDefinitionsFromXmlDoc(Doc.get(), RootElement);
+}
+
+llvm::Error CppcheckDefinitionsParser::parseDefinitionsFromXmlDoc(xmlDocPtr Doc, xmlNode *RootElement) {
+  XmlCharUPtr DefFormat = wrap(xmlGetProp(RootElement, cast("format")));
+  if (!DefFormat) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "could not get 'format' attribute from <def> element");
+  }
+  if (!StringRef(cast(DefFormat.get())).equals("2")) {
+    return llvm::createStringError(
+	llvm::inconvertibleErrorCode(), "unsupported file format: %s", cast(DefFormat.get()));
+  }
+
+  for (xmlNode *CurrNode = RootElement->children; CurrNode != nullptr; CurrNode = CurrNode->next) {
+    if (CurrNode->type == XML_ELEMENT_NODE) {
+      StringRef Name = cast(CurrNode->name);
+      if (Name.equals("memory") || Name.equals("resource")) {
+	if (auto Error = parseMemoryDefintion(Doc, CurrNode)) {
+	  return Error;
+	}
+      }
+    }
+  }
+
+  return llvm::Error::success();
+}
+
+llvm::Error CppcheckDefinitionsParser::parseMemoryDefintion(xmlDocPtr Doc, xmlNode *Node) {
+  assert(Node && "Node must not be NULL");
+
+  DeclarativeFunctionClassifier::ResourceFuncFamily Family;
+
+  for (xmlNode *CurrNode = Node->children; CurrNode != nullptr; CurrNode = CurrNode->next) {
+    if (CurrNode->type != XML_ELEMENT_NODE) {
+      continue;
+    }
+    StringRef Name = cast(CurrNode->name);
+    if (Name.equals("alloc")) {
+      XmlCharUPtr Value = wrap(xmlNodeListGetString(Doc, CurrNode->children, 0));
+      if (Value && Family.AcquireName.empty()) {
+	Family.AcquireName = cast(Value.get());
+      }
+      // TODO: handle the 'init' attribute
+    } else if (Name.equals("dealloc")) {
+      XmlCharUPtr Value = wrap(xmlNodeListGetString(Doc, CurrNode->children, 0));
+      if (Value && Family.ReleaseName.empty()) {
+	Family.ReleaseName = cast(Value.get());
+      }
+    } else {
+      return llvm::createStringError(
+          llvm::inconvertibleErrorCode(), "unsupported element found: %s", Name.data());
+    }
+  }
+
+  if (Family.AcquireName.empty() || Family.ReleaseName.empty()) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+	"incomplete family defintion { %s -> %s }", Family.AcquireName.c_str(), Family.ReleaseName.c_str());
+  }
+
+  assert(Callback != nullptr && "internal error - Callback must not be nullptr!");
+  (*Callback)(Family);
+  return llvm::Error::success();
+}
+
+} // end namespace ento
+} // end namespace clang

--- a/lib/StaticAnalyzer/Checkers/CppcheckDefinitionsParser.h
+++ b/lib/StaticAnalyzer/Checkers/CppcheckDefinitionsParser.h
@@ -1,0 +1,38 @@
+// TODO: copyright
+
+#ifndef LLVM_CLANG_STATICANALYZER_CHECKERS_CPPCHECKDEFINITIONSPARSER_H
+#define LLVM_CLANG_STATICANALYZER_CHECKERS_CPPCHECKDEFINITIONSPARSER_H
+
+#include "DeclarativeFunctionClassifier.h"
+#include "clang/Config/config.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include <functional>
+#include <memory>
+#include <system_error>
+
+#ifdef CLANG_HAVE_LIBXML
+#include <libxml/parser.h>
+#endif
+
+namespace clang {
+namespace ento {
+
+class CppcheckDefinitionsParser {
+  public:
+    CppcheckDefinitionsParser() = default;
+
+    using ParserCallback = std::function<void(DeclarativeFunctionClassifier::ResourceFuncFamily)>;
+    llvm::Error parse(StringRef Text, ParserCallback Callback);
+
+  private:
+    llvm::Error parseDefinitionsFromXmlDoc(xmlDocPtr Doc, xmlNode *RootElement);
+    llvm::Error parseMemoryDefintion(xmlDocPtr Doc, xmlNode *Node);
+
+    ParserCallback *Callback = nullptr;
+};
+
+} // end namespace ento
+} // end namespace clang
+
+#endif

--- a/lib/StaticAnalyzer/Checkers/DeclarativeFunctionClassifier.cpp
+++ b/lib/StaticAnalyzer/Checkers/DeclarativeFunctionClassifier.cpp
@@ -1,0 +1,76 @@
+#include "DeclarativeFunctionClassifier.h"
+#include "clang/Basic/VirtualFileSystem.h"
+#include "clang/Config/config.h"
+#include "llvm/Support/Debug.h"
+#include <cassert>
+#include <type_traits>
+
+#define DEBUG_TYPE "DeclarativeFunctionClassifier"
+
+namespace clang {
+namespace ento {
+
+llvm::Error DeclarativeFunctionClassifier::loadDefinitions(StringRef Paths, DefinitionsFileCallback Callback) {
+  if (Paths.empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "the list of paths to definitions is empty, loading definitions skipped\n");
+    return llvm::Error::success();
+  }
+
+  llvm::SmallVector<StringRef, 5> SplittedPaths;
+  Paths.split(SplittedPaths, StringRef(","));
+
+  auto FS = vfs::getRealFileSystem();
+  assert(FS);
+
+  for (auto Path : SplittedPaths) {
+    auto Text = FS->getBufferForFile(Path);
+    if (Text.getError()) {
+      return llvm::createStringError(
+          Text.getError(), "failed to read '%s': %s", Path.str().c_str(), Text.getError().message().c_str());
+    }
+    LLVM_DEBUG(llvm::dbgs() << "read '" << Path << "'\n");
+    Callback(Text.get()->getBuffer());
+  }
+  return llvm::Error::success();
+}
+
+void DeclarativeFunctionClassifier::addResourceFuncFamily(ResourceFuncFamily Family) {
+  LLVM_DEBUG(llvm::dbgs() << "added function family { " << Family.AcquireName << " -> " << Family.ReleaseName << " }\n");
+  Repository.push_back(std::move(Family));
+}
+
+void DeclarativeFunctionClassifier::identifierInit(ASTContext &ASTCtx) {
+  for (auto &Family : Repository) {
+    assert(!Family.II_acquire && !Family.II_release && "init must not be called more than once");
+    assert(!Family.AcquireName.empty() && "internal error - acquire name should not be empty");
+    assert(!Family.ReleaseName.empty() && "internal error - release name should not be empty");
+    Family.II_acquire = &ASTCtx.Idents.get(Family.AcquireName);
+    Family.II_release = &ASTCtx.Idents.get(Family.ReleaseName);
+  }
+}
+
+DeclarativeFunctionClassifier::FuncInfo
+    DeclarativeFunctionClassifier::getFuncInfo(const IdentifierInfo *const IdentInfo) const {
+  // TODO: improve search algorithm performance if needed
+  for (auto &Family : Repository) {
+    if (Family.II_acquire == IdentInfo) {
+      return FuncInfo::ACQUIRE;
+    } else if (Family.II_release == IdentInfo) {
+      return FuncInfo::RELEASE;
+    }
+  }
+  return FuncInfo::UNKNOWN;
+}
+
+const DeclarativeFunctionClassifier::ResourceFuncFamily *
+DeclarativeFunctionClassifier::getFamily(const IdentifierInfo *const AllocIdentInfo) const {
+  for (auto &Family : Repository) {
+    if (Family.II_acquire == AllocIdentInfo) {
+      return &Family;
+    }
+  }
+  return nullptr;
+}
+
+} // end namespace ento
+} // end namespace clang

--- a/lib/StaticAnalyzer/Checkers/DeclarativeFunctionClassifier.h
+++ b/lib/StaticAnalyzer/Checkers/DeclarativeFunctionClassifier.h
@@ -1,0 +1,64 @@
+// TODO: copyright
+
+#ifndef LLVM_CLANG_STATICANALYZER_CHECKERS_DECLARATIVEFUNCTIONCLASSIFIER_H
+#define LLVM_CLANG_STATICANALYZER_CHECKERS_DECLARATIVEFUNCTIONCLASSIFIER_H
+
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include <functional>
+#include <memory>
+#include <string>
+#include <system_error>
+
+namespace clang {
+namespace ento {
+
+class DeclarativeFunctionClassifier {
+  public:
+    enum class Status {
+      SUCCESS,
+      ERROR
+    };
+
+    enum class FuncInfo {
+      UNKNOWN,
+      ACQUIRE,
+      RELEASE
+    };
+
+    struct ResourceFuncFamily {
+      ResourceFuncFamily()
+          : II_acquire(nullptr), II_release(nullptr) {}
+      ResourceFuncFamily(IdentifierInfo* II_acquire, IdentifierInfo* II_release)
+          : II_acquire(II_acquire), II_release(II_release) {}
+
+      // TODO: can IdentifierInfo::getName() be used to check the name?
+
+      std::string AcquireName;
+      IdentifierInfo* II_acquire;
+
+      std::string ReleaseName;
+      IdentifierInfo* II_release;
+    };
+
+    using DefinitionsFileCallback = std::function<void(StringRef)>;
+    llvm::Error loadDefinitions(StringRef Paths, DefinitionsFileCallback Callback);
+
+    void addResourceFuncFamily(ResourceFuncFamily Family);
+
+    void identifierInit(ASTContext &ASTCtx);
+
+    FuncInfo getFuncInfo(const IdentifierInfo *const IdentInfo) const;
+
+    const ResourceFuncFamily *getFamily(const IdentifierInfo *const AllocIdentInfo) const;
+
+  private:
+    using ResourceFuncFamilyRepository = std::vector<ResourceFuncFamily>;
+    ResourceFuncFamilyRepository Repository;
+};
+
+} // end namespace ento
+} // end namespace clang
+
+#endif


### PR DESCRIPTION
Initially offers support for malloc/dealloc function definitions
provided by Cppcheck.